### PR TITLE
Feat: Create Drag and Drop for Opening the folder

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain } from "electron";
+import { app, shell, BrowserWindow } from "electron";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 
@@ -38,8 +38,6 @@ app.whenReady().then(() => {
   app.on("browser-window-created", (_, window) => {
     optimizer.watchWindowShortcuts(window);
   });
-
-  ipcMain.on("ping", () => console.log("pong"));
 
   createWindow();
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,20 +1,16 @@
-import { contextBridge } from 'electron'
-import { electronAPI } from '@electron-toolkit/preload'
+import { contextBridge } from "electron";
+import { electronAPI } from "@electron-toolkit/preload";
 
-// Custom APIs for renderer
-const api = {}
+const api = {};
 
-// Use `contextBridge` APIs to expose Electron APIs to
-// renderer only if context isolation is enabled, otherwise
-// just add to the DOM global.
 if (process.contextIsolated) {
   try {
-    contextBridge.exposeInMainWorld('electron', electronAPI)
-    contextBridge.exposeInMainWorld('api', api)
+    contextBridge.exposeInMainWorld("electron", electronAPI);
+    contextBridge.exposeInMainWorld("api", api);
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
 } else {
-  window.electron = electronAPI
-  window.api = api
+  window.electron = electronAPI;
+  window.api = api;
 }

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -1,12 +1,49 @@
+import { useState } from "react";
+
 function Home() {
+  const [message, setMessage] = useState({
+    show: false,
+    text: null,
+  });
+  const [projectPath, setProjectPath] = useState("");
+
+  function handleDrop(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const items = event.dataTransfer.items;
+
+    if (items.length === 1 && items[0].webkitGetAsEntry().isDirectory) {
+      const fullPath = items[0].getAsFile().path;
+
+      setProjectPath(fullPath);
+      setMessage({ show: true, text: "Let's Check Your CSS!" });
+    }
+  }
+
+  function handleDragOver(event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
   return (
     <main className="flex justify-center items-center flex-col mt-10 h-96">
-      <div className="flex justify-center items-center flex-col relative w-3/5 h-2/3 border rounded-2xl bg-gray-200 text-6xl font-bold">
-        <p className="text-lg">Drop your project here.</p>
-        <p>+</p>
-        <button className="absolute bottom-8 p-3 rounded-xl bg-gray text-lg font-bold hover:bg-black hover:text-white">
-          Load Project
-        </button>
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        className="flex justify-center items-center flex-col relative w-3/5 h-2/3 border rounded-2xl bg-gray-200 text-6xl font-bold"
+      >
+        {message.show ? (
+          <p className="text-4xl">{message.text}</p>
+        ) : (
+          <>
+            <p className="text-lg">Drop your project here.</p>
+            <p>+</p>
+            <button className="absolute bottom-8 p-3 rounded-xl bg-gray text-lg font-bold hover:bg-black hover:text-white">
+              Load Project
+            </button>
+          </>
+        )}
       </div>
       <div className="flex justify-evenly m-3 w-full">
         <div className="flex">


### PR DESCRIPTION
## 내용
- 폴더를 불러오기 위한 Drag & Drop을 구현하였습니다.
- 기능 구현을 위해 Drag & Drop API인 DataTransfer 객체를 사용하였습니다. ([참고](https://developer.mozilla.org/ko/docs/Web/API/DataTransfer))
  - DataTransfer 객체가 가지는 `items` 속성을 이용하여 drag 작업에서 전송된 데이터 항목을 가져왔고, `webkitGetAsEntry()` 메서드를 사용하여 가져온 데이터가 폴더인지 확인하였습니다.
- `onDragOver`과 `onDrop` 이벤트 속성을 사용하여 요소가 drag 또는 drop할 때 반응하는 이벤트를 가져왔습니다. 그리고 `handleDragOver`과 `handleDrop` 함수를 만들어 적용해주었습니다.
<br/>

## 변경 사항
1. Home.jsx
  - `message`, `projectPath` state 추가
  - 일부 HTML 구조 변경
2. preload/index.js
  - style 변경(세미콜론 누락 및 따옴표 수정)
<br/>

## 체크리스트
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
<br/>


