### PR TITLE
Feat: Get CSS data by caniuse

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,7 @@
 import { app, shell, BrowserWindow, ipcMain, dialog } from "electron";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
+import axios from "axios";
 
 function createWindow() {
   const mainWindow = new BrowserWindow({
@@ -15,6 +16,8 @@ function createWindow() {
       sandbox: false,
     },
   });
+
+  mainWindow.webContents.openDevTools();
 
   mainWindow.on("ready-to-show", () => {
     mainWindow.show();
@@ -40,6 +43,14 @@ app.whenReady().then(() => {
   });
 
   createWindow();
+
+  ipcMain.handle("get-data", async () => {
+    const response = await axios.get(
+      "https://raw.githubusercontent.com/Fyrd/caniuse/main/fulldata-json/data-2.0.json",
+    );
+
+    return response.data;
+  });
 
   ipcMain.handle("open-directory", async (event, args) => {
     const { filePaths } = await dialog.showOpenDialog({

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -17,8 +17,6 @@ function createWindow() {
     },
   });
 
-  mainWindow.webContents.openDevTools();
-
   mainWindow.on("ready-to-show", () => {
     mainWindow.show();
   });

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -3,7 +3,9 @@ import { electronAPI } from "@electron-toolkit/preload";
 
 if (process.contextIsolated) {
   try {
-    contextBridge.exposeInMainWorld("electron", electronAPI);
+    contextBridge.exposeInMainWorld("fullCssDataAPI", {
+      getFullCssData: () => ipcRenderer.invoke("get-data"),
+    });
     contextBridge.exposeInMainWorld("loadProjectAPI", {
       openDirectory: () => ipcRenderer.invoke("open-directory"),
     });

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -1,11 +1,73 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 function Home() {
+  const [fullData, setFullData] = useState(null);
+  const [browsers, setBrowsers] = useState(null);
   const [message, setMessage] = useState({
     show: false,
     text: null,
   });
   const [projectPath, setProjectPath] = useState("");
+
+  useEffect(() => {
+    async function getData() {
+      try {
+        const data = await window.fullCssDataAPI.getFullCssData();
+        const agentsData = data.agents;
+
+        setFullData(data);
+        setBrowsers({
+          Chrome: {
+            version: agentsData.chrome.version_list,
+            stat: "chrome",
+          },
+          FireFox: {
+            version: agentsData.firefox.version_list,
+            stat: "firefox",
+          },
+          Safari: {
+            version: agentsData.safari.version_list,
+            stat: "safari",
+          },
+          Edge: {
+            version: agentsData.edge.version_list,
+            stat: "edge",
+          },
+          Opera: {
+            version: agentsData.opera.version_list,
+            stat: "opera",
+          },
+          Samsung_Mobile: {
+            version: agentsData.samsung.version_list,
+            stat: "samasung",
+          },
+          Chrome_for_android: {
+            version: agentsData.and_chr.version_list,
+            stat: "and_chr",
+          },
+
+          Android: {
+            version: agentsData.android.version_list,
+            stat: "android",
+          },
+
+          Safari_on_iOS: {
+            version: agentsData.ios_saf.version_list,
+            stat: "ios_saf",
+          },
+
+          FireFox_for_android: {
+            version: agentsData.and_ff.version_list,
+            stat: "and_ff",
+          },
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    getData();
+  }, []);
 
   async function selectFolder() {
     const fullPath = await window.loadProjectAPI.openDirectory();


### PR DESCRIPTION
## 내용
- axios를 사용하여 caniuse github에서 css 데이터 받아왔습니다.
- 받아온 데이터를 추후에 사용하기 편하도록 전처리하였습니다.
- 어플이 시작되자마자 필요하기에 처음 홈페이지 렌더링 시 받아올 수있게 하였습니다.
- preload폴더에서 fullCssDataAPI 채널 추가하였습니다.

[받아온 데이터 전처리 코드](https://github.com/TeamTitans1/checkyourcss/compare/feat_css_data_by_caniuse?expand=1#diff-0750b4c42bbf8175c618022a550812d893158bcaea548bd96007c4c2f6ded89eR19-R62)
<br/>

## 변경 사항
- preload폴더에서 사용하지 않는 채널(electron)삭제하였습니다.
<br/>

## 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
<br/>

![스크린샷 2024-02-03 오후 6 07 07](https://github.com/TeamTitans1/checkyourcss/assets/115441816/96c6f8f8-1e58-4002-a974-4aaa545f369e)



