### PR TITLE
Feat: Create brower and version select box

### DIFF
--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from "react";
 function Home() {
   const [fullData, setFullData] = useState(null);
   const [browsers, setBrowsers] = useState(null);
+  const [selections, setSelections] = useState([{ browser: "", version: "" }]);
+  const [cssType, setCssType] = useState("");
   const [message, setMessage] = useState({
     show: false,
     text: null,
@@ -95,12 +97,27 @@ function Home() {
     event.stopPropagation();
   }
 
+  function addSelection() {
+    setSelections([...selections, { browser: "", version: "" }]);
+  }
+
+  function updateSelection(index, browserOrVersion, value) {
+    const updatedSelections = [...selections];
+
+    updatedSelections[index][browserOrVersion] = value;
+    setSelections(updatedSelections);
+  }
+
+  function handleRadioOnChange(event) {
+    setCssType(event.target.value);
+  }
+
   return (
-    <main className="flex justify-center items-center flex-col mt-10 h-96">
+    <main className="flex justify-center items-center flex-col h-screen">
       <div
         onDrop={handleDrop}
         onDragOver={handleDragOver}
-        className="flex justify-center items-center flex-col relative w-3/5 h-2/3 border rounded-2xl bg-gray-200 text-6xl font-bold"
+        className="flex mt-10 justify-center items-center flex-col relative w-3/5 h-2/5 border rounded-2xl bg-gray-200 text-6xl font-bold"
       >
         {message.show ? (
           <p className="text-4xl">{message.text}</p>
@@ -118,33 +135,79 @@ function Home() {
         )}
       </div>
       <div className="flex justify-evenly m-3 w-full">
-        <div className="flex">
-          <select
-            name="browsers"
-            id="browsers"
-            className="bg-gray text-sm rounded-lg focus:ring-blue focus:border-blue-500 block py-1 px-3"
-          >
-            <option value="Chrome">Chrome</option>
-          </select>
-          <select
-            name="versions"
-            id="versions"
-            className="bg-gray text-sm rounded-lg focus:ring-blue focus:border-blue-500 block py-1 px-3 mx-4"
-          >
-            <option value="version">124</option>
-          </select>
-          <button className="px-2 rounded-full bg-gray text-lg font-bold hover:bg-black hover:text-white">
-            +
-          </button>
-        </div>
         <div>
-          <input type="radio" name="cssType" id="utility-first-css" />
+          {selections.map((selection, index) => (
+            <div key={index} className="flex mb-3">
+              <select
+                name="browsers"
+                id="browsers"
+                value={selection.browser}
+                onChange={e =>
+                  updateSelection(index, "browser", e.target.value)
+                }
+                className="bg-gray text-sm rounded-lg focus:ring-blue focus:border-blue-500 block py-1 px-3"
+              >
+                <option value="">브라우저</option>
+                {browsers &&
+                  Object.keys(browsers).map(browser => (
+                    <option key={browser} value={browser}>
+                      {browser}
+                    </option>
+                  ))}
+              </select>
+              <select
+                name="versions"
+                id="versions"
+                value={selection.browser.version}
+                onChange={e =>
+                  updateSelection(index, "version", e.target.value)
+                }
+                disabled={!selection.browser}
+                className="bg-gray text-sm rounded-lg focus:ring-blue focus:border-blue-500 block py-1 px-3 mx-4"
+              >
+                <option value="">버전</option>
+                {selection.browser &&
+                  browsers[selection.browser].version
+                    .slice()
+                    .reverse()
+                    .map(versionObj => (
+                      <option
+                        key={versionObj.version}
+                        value={versionObj.version}
+                      >
+                        {versionObj.version}
+                      </option>
+                    ))}
+              </select>
+              <button
+                onClick={addSelection}
+                className="px-2 rounded-full bg-gray text-lg font-bold hover:bg-black hover:text-white"
+              >
+                +
+              </button>
+            </div>
+          ))}
+        </div>
+        <form>
+          <input
+            type="radio"
+            name="cssType"
+            id="utility-first-css"
+            value="utility-first-css"
+            onClick={handleRadioOnChange}
+          />
           <label htmlFor="utility-first-css" className="pr-4 ">
             Utility-first CSS
           </label>
-          <input type="radio" name="cssType" id="css-in-js" />
+          <input
+            type="radio"
+            name="cssType"
+            id="css-in-js"
+            value="css-in-js"
+            onClick={handleRadioOnChange}
+          />
           <label htmlFor="css-in-js">CSS-in-JS</label>
-        </div>
+        </form>
       </div>
       <button className="mt-8 px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black">
         Check!

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -3,8 +3,10 @@ import { useState, useEffect } from "react";
 function Home() {
   const [fullData, setFullData] = useState(null);
   const [browsers, setBrowsers] = useState(null);
-  const [selections, setSelections] = useState([{ browser: "", version: "" }]);
-  const [cssType, setCssType] = useState("");
+  const [userSelections, setUserSelections] = useState([
+    { browser: "", version: "" },
+  ]);
+  const [cssFrameworkType, setCssFrameworkType] = useState("");
   const [message, setMessage] = useState({
     show: false,
     text: null,
@@ -98,26 +100,26 @@ function Home() {
   }
 
   function addSelection() {
-    setSelections([...selections, { browser: "", version: "" }]);
+    setUserSelections([...userSelections, { browser: "", version: "" }]);
   }
 
   function updateSelection(index, browserOrVersion, value) {
-    const updatedSelections = [...selections];
+    const updatedSelections = [...userSelections];
 
     updatedSelections[index][browserOrVersion] = value;
-    setSelections(updatedSelections);
+    setUserSelections(updatedSelections);
   }
 
-  function handleRadioOnChange(event) {
-    setCssType(event.target.value);
+  function handleRadioOnClick(event) {
+    setCssFrameworkType(event.target.value);
   }
 
   return (
-    <main className="flex justify-center items-center flex-col h-screen">
+    <main className="flex justify-center items-center flex-col mt-10 h-96">
       <div
         onDrop={handleDrop}
         onDragOver={handleDragOver}
-        className="flex mt-10 justify-center items-center flex-col relative w-3/5 h-2/5 border rounded-2xl bg-gray-200 text-6xl font-bold"
+        className="flex justify-center items-center flex-col relative w-3/5 h-2/3 border rounded-2xl bg-gray-200 text-6xl font-bold"
       >
         {message.show ? (
           <p className="text-4xl">{message.text}</p>
@@ -136,7 +138,7 @@ function Home() {
       </div>
       <div className="flex justify-evenly m-3 w-full">
         <div>
-          {selections.map((selection, index) => (
+          {userSelections.map((selection, index) => (
             <div key={index} className="flex mb-3">
               <select
                 name="browsers"
@@ -170,12 +172,12 @@ function Home() {
                   browsers[selection.browser].version
                     .slice()
                     .reverse()
-                    .map(versionObj => (
+                    .map(selectedBrowserVersion => (
                       <option
-                        key={versionObj.version}
-                        value={versionObj.version}
+                        key={selectedBrowserVersion.version}
+                        value={selectedBrowserVersion.version}
                       >
-                        {versionObj.version}
+                        {selectedBrowserVersion.version}
                       </option>
                     ))}
               </select>
@@ -194,7 +196,7 @@ function Home() {
             name="cssType"
             id="utility-first-css"
             value="utility-first-css"
-            onClick={handleRadioOnChange}
+            onClick={handleRadioOnClick}
           />
           <label htmlFor="utility-first-css" className="pr-4 ">
             Utility-first CSS
@@ -204,7 +206,7 @@ function Home() {
             name="cssType"
             id="css-in-js"
             value="css-in-js"
-            onClick={handleRadioOnChange}
+            onClick={handleRadioOnClick}
           />
           <label htmlFor="css-in-js">CSS-in-JS</label>
         </form>


### PR DESCRIPTION
## 내용
- 모양만 만들어 두었던 두개의 select태그에 각각 브라우저와 브라우저별 버전정보를 넣어 유저가 선택할 수 있도록 변경 하였습니다.
- 선택시 값은 selections라는 배열안에 객체로 생성됩니다.
- 브라우저 미선택 시 버전은 선택할 수 없도록 disabled옵션을 사용하였습니다.
- +버튼을 클릭하면 addSelection함수를 사용하여 기존과 같은 양식의 선택지를 추가하도록 하였습니다.
- Radio 타입으로 만들어진 Utility-first CSS, CSS-in-JS 중 하나만 선택할 수 있으면 선택시 선택한 input의 값을 useState를 통해 저장하였습니다.
- 선택시 값은 cssType이라는 변수에 string값으로 할당됩니다.
<br/>

## 변경 사항
- select태그의 선택 옵션에 브라우저들 추가
- 선택된 브라우저에 따라 선택할 버전들을 select태그의 옵션에 추가
<br/>

## 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
<br/>

## 참고사항
버전을 선택하는 과정에서 로직이 조금 복잡하다고 생각이 됩니다. 코드가 잘 읽히지 않는게 있으면 말씀해주시길 바랍니다. 

