### PR TITLE
Feat: Create Detail Component

### DIFF
--- a/src/renderer/src/components/Detail.jsx
+++ b/src/renderer/src/components/Detail.jsx
@@ -1,0 +1,19 @@
+import NotSupport from "./NotSupport";
+import PartialSupport from "./PartialSupport";
+
+function Detail({ cssInfo, isNotSupportCss }) {
+  return (
+    <section className="flex justify-center items-center flex-col h-screen mt-10">
+      {isNotSupportCss ? (
+        <NotSupport />
+      ) : (
+        <PartialSupport cssProperty={cssInfo} />
+      )}
+      <button className="mt-14 px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-white hover:text-black hover:border">
+        Go to Your Code!
+      </button>
+    </section>
+  );
+}
+
+export default Detail;

--- a/src/renderer/src/components/NotSupport.jsx
+++ b/src/renderer/src/components/NotSupport.jsx
@@ -1,0 +1,33 @@
+function NotSupport() {
+  return (
+    <div className="flex justify-evenly items-center flex-col mt-10 bg-red-5 w-4/5 h-80 scroll-auto">
+      <h3 className="font-bold">
+        <span className="text-red">text-box-trim</span> on{" "}
+        <span className="underline">line 13</span> is not supported.
+      </h3>
+      <div>
+        <div className="flex">
+          <div>
+            <h4 className="text-2xl font-extrabold">Chrome</h4>
+            <p className="text-xs">Version</p>
+            <div className="flex justify-center items-center h-16 bg-red text-xl text-white">
+              4 - 124
+            </div>
+          </div>
+          <div className="ml-10">
+            <h4 className="text-2xl font-extrabold">FireFox</h4>
+            <p className="text-xs">Version</p>
+            <div className="flex justify-center items-center h-16 bg-red text-xl text-white">
+              2 - 125
+            </div>
+          </div>
+          <div className="mx-10 my-2 p-4 h-auto bg-red-200">
+            <p>style.css in /User/Desktop/project</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default NotSupport;

--- a/src/renderer/src/components/PartialSupport.jsx
+++ b/src/renderer/src/components/PartialSupport.jsx
@@ -1,0 +1,56 @@
+function PartialSupport({ cssProperty }) {
+  return (
+    <div className="flex justify-evenly items-center flex-col mt-10 bg-yellow-100 w-5/6 h-80">
+      <h3 className="font-bold">
+        <span className="text-yellow">{cssProperty}</span> on{" "}
+        <span className="underline">line 13</span> is partially supported.
+      </h3>
+      <div>
+        <div className="flex">
+          <div className="mx-3">
+            <h4 className="text-2xl font-extrabold">Chrome</h4>
+            <p className="text-xs">Version</p>
+            <div>
+              <div className="flex justify-center items-center h-12 bg-red text-xl text-white">
+                4
+              </div>
+              <div className="flex justify-center items-center h-12 mt-3 bg-yellow text-xl text-white">
+                5 - 124
+              </div>
+            </div>
+          </div>
+          <div className="mx-5 my-2 p-4 h-auto bg-yellow-200">
+            <h5 className="font-bold">Description</h5>
+            <p className="bg-yellow-300 mb-3">
+              WebKit implements something similar with a different name
+              `-webkit-font-smoothing` and different values: `none`,
+              `antialiased` and `subpixel-antialiased`.
+            </p>
+            <h5 className="font-bold">Example</h5>
+          </div>
+          <div className="ml-5">
+            <h4 className="text-2xl font-extrabold">FireFox</h4>
+            <p className="text-xs">Version</p>
+            <div className="flex justify-center items-center h-12 bg-red text-xl text-white">
+              2 - 24
+            </div>
+            <div className="flex justify-center items-center h-12 mt-3 bg-yellow text-xl text-white">
+              25 - 124
+            </div>
+          </div>
+          <div className="mx-5 my-2 p-4 h-auto bg-yellow-200">
+            <h5 className="font-bold">Description</h5>
+            <p className="bg-yellow-300 mb-3">
+              Firefox implements something similar with a different name
+              `-moz-osx-font-smoothing` and different values: `auto`, `inherit`,
+              `unset`, `grayscale`.
+            </p>
+            <h5 className="font-bold">Example</h5>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PartialSupport;

--- a/src/renderer/src/components/Result.jsx
+++ b/src/renderer/src/components/Result.jsx
@@ -1,8 +1,13 @@
 import { FaCheck } from "react-icons/fa";
+import Detail from "./Detail";
+import { useState } from "react";
 
 function Result({ isPerfect, cssInfo, userSelections }) {
   const notSupportedProperties = [];
   const partialSupportProperties = [];
+  const [isDetailClicked, setIsDetailClicked] = useState(false);
+  const [isClickNotSupportCss, setIsClickNotSupportCss] = useState(true);
+  const [clickedValue, setClickedValue] = useState("");
 
   cssInfo.forEach(item => {
     if (item.compatibility === "n") {
@@ -53,75 +58,82 @@ function Result({ isPerfect, cssInfo, userSelections }) {
           </div>
         </main>
       ) : (
-        <main className="flex justify-center items-center flex-col h-screen pt-36">
-          <p>
-            CSS Compatibility in your Browser,{" "}
-            {userSelections.map((selection, index) => {
-              return (
-                <>
-                  <span key={index} className="font-bold">
-                    {selection.browser}{" "}
-                  </span>
-                  <span key={index} className="font-bold">
-                    {selection.version}
-                    {userSelections.length - 1 === index ? "" : ","}{" "}
-                  </span>
-                </>
-              );
-            })}{" "}
-            is
-          </p>
-          <div className="flex justify-evenly h-96 w-4/5 mb-2">
-            <div className="flex items-center flex-col m-10">
-              <div className="flex justify-center items-center border-8 w-24 h-24 border-red rounded-full mb-2 text-4xl">
-                {notSupportedProperties.length}
-              </div>
-              <div>Not Supported</div>
-            </div>
-            <div className="flex items-center flex-col m-10">
-              <div className="flex justify-center items-center border-8 w-24 h-24 border-yellow rounded-full mb-2 text-4xl">
-                {partialSupportProperties.length}
-              </div>
-              <div>Partial Supported</div>
-            </div>
-          </div>
-          <div className="h-4/5 w-4/5">
-            <div className="ml-14 text-xs">Not Supported</div>
-            <div className="flex items-center flex-col mb-3">
-              <form className="flex items-center w-4/5 h-16 border-2 border-red">
-                {notSupportedProperties.map(property => {
+        <>
+          {!isDetailClicked ? (
+            <main className="flex justify-center items-center flex-col h-screen pt-36">
+              <div>
+                CSS Compatibility in your Browser,{" "}
+                {userSelections.map((selection, index) => {
                   return (
-                    <button
-                      key={property}
-                      value={property}
-                      className="p-1 h-8 bg-red-200 ml-5"
-                      onClick={handlePropertyClick}
-                    >
-                      {property}
-                    </button>
+                    <div key={index} className="mx-2">
+                      <span className="font-bold">{selection.browser}</span>
+                      <span className="font-bold">
+                        {selection.version}
+                        {userSelections.length - 1 === index ? "" : ","}{" "}
+                      </span>
+                    </div>
                   );
-                })}
-              </form>
-            </div>
-            <div className="ml-14 text-xs">Partial Supported</div>
-            <div className="flex items-center flex-col">
-              <form className="flex items-center w-4/5 h-16 border-2 border-yellow">
-                {partialSupportProperties.map(property => {
-                  return (
-                    <button
-                      key={property}
-                      value={property}
-                      className="p-1 h-8 bg-red-200 ml-5"
-                      onClick={handlePropertyClick}
-                    >
-                      {property}
-                    </button>
-                  );
-                })}
-              </form>
-            </div>
-          </div>
-        </main>
+                })}{" "}
+                is
+              </div>
+              <div className="flex justify-evenly h-96 w-4/5 mb-2">
+                <div className="flex items-center flex-col m-10">
+                  <div className="flex justify-center items-center border-8 w-24 h-24 border-red rounded-full mb-2 text-4xl">
+                    {notSupportedProperties.length}
+                  </div>
+                  <div>Not Supported</div>
+                </div>
+                <div className="flex items-center flex-col m-10">
+                  <div className="flex justify-center items-center border-8 w-24 h-24 border-yellow rounded-full mb-2 text-4xl">
+                    {partialSupportProperties.length}
+                  </div>
+                  <div>Partial Supported</div>
+                </div>
+              </div>
+              <div className="h-4/5 w-4/5">
+                <div className="ml-14 text-xs">Not Supported</div>
+                <div className="flex items-center flex-col mb-3">
+                  <form className="flex items-center w-4/5 h-16 border-2 border-red">
+                    {notSupportedProperties.map(property => {
+                      return (
+                        <button
+                          key={property}
+                          value={property}
+                          className="p-1 h-8 bg-red-200 ml-5"
+                          onClick={handlePropertyClick}
+                        >
+                          {property}
+                        </button>
+                      );
+                    })}
+                  </form>
+                </div>
+                <div className="ml-14 text-xs">Partial Supported</div>
+                <div className="flex items-center flex-col">
+                  <form className="flex items-center w-4/5 h-16 border-2 border-yellow">
+                    {partialSupportProperties.map(property => {
+                      return (
+                        <button
+                          key={property}
+                          value={property}
+                          className="p-1 h-8 bg-red-200 ml-5"
+                          onClick={handlePropertyClick}
+                        >
+                          {property}
+                        </button>
+                      );
+                    })}
+                  </form>
+                </div>
+              </div>
+            </main>
+          ) : (
+            <Detail
+              cssInfo={clickedValue}
+              isNotSupportCss={isClickNotSupportCss}
+            />
+          )}
+        </>
       )}
     </>
   );


### PR DESCRIPTION
## 내용
- Detail 컴포넌트에서 props로 받아온 isNotSupportCss를 통해 Result 컴포넌트에서 클릭된 값이 partialySupport인지 notSupport인지 확인하여 isNotSupportCss true이면 NotSupport컴포넌트를 보여주고 아니면 PartialSupport컴포넌트를 보여줍니다.
```
{isNotSupportCss ? (
  <NotSupport />
) : (
  <PartialSupport cssProperty={cssInfo} />
      )}
```

![스크린샷 2024-02-06 오전 11 20 57](https://github.com/TeamTitans1/checkyourcss/assets/115441816/625395f4-2c11-4325-94ce-c4188fe18fa4)

- partialySupportcss를 눌렀을 때 해당 값이 Result에서 Detail 컴포넌트로 옮겨주기 위해 props로 받아와 사용하였습니다.
<br/>

```
<PartialSupport cssProperty={cssInfo} />
```
- 이와 마찬가지로 NotSupport 컴포넌트에도 추가할 예정입니다.

## 변경 사항
- 같은 키가 사용되고 있다는 에러가 발생해
```
<div key={index} className="mx-2">
  <span className="font-bold">{selection.browser}</span>
  <span className="font-bold">
    {selection.version}
    {userSelections.length - 1 === index ? "" : ","}{" "}
  </span>
</div>
```
으로 변경하였습니다.

<br/>

## 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
<br/>

## 참고사항
기타 참고할 사항이 있다면 여기에 기록해주세요.
<br/>

