### PR TITLE
Feat: Show the browers and versions that are selected by user

### DIFF
--- a/src/renderer/src/components/Detail.jsx
+++ b/src/renderer/src/components/Detail.jsx
@@ -1,11 +1,22 @@
 import NotSupport from "./NotSupport";
 import PartialSupport from "./PartialSupport";
 
-function Detail({ cssInfo, isNotSupportCss }) {
+function Detail({
+  cssData,
+  cssInfo,
+  isNotSupportCss,
+  userSelections,
+  browsers,
+}) {
   return (
     <section className="flex justify-center items-center flex-col h-screen mt-10">
       {isNotSupportCss ? (
-        <NotSupport />
+        <NotSupport
+          cssData={cssData}
+          cssProperty={cssInfo}
+          userSelections={userSelections}
+          browsers={browsers}
+        />
       ) : (
         <PartialSupport cssProperty={cssInfo} />
       )}

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -299,6 +299,8 @@ function Home() {
           isPerfect={isAllCompatible}
           cssInfo={cssCompatibilityResult}
           userSelections={userSelections}
+          cssData={fullData}
+          browsers={browsers}
         />
       )}
     </>

--- a/src/renderer/src/components/NotSupport.jsx
+++ b/src/renderer/src/components/NotSupport.jsx
@@ -22,7 +22,6 @@ function NotSupport({ cssData, cssProperty, userSelections, browsers }) {
 
     if (browserCompatibilityByVersions) {
       for (const version in browserCompatibilityByVersions) {
-        userSelections.forEach(userSelect => {});
         const compatibility = browserCompatibilityByVersions[version];
 
         if (compatibility === "n") {

--- a/src/renderer/src/components/NotSupport.jsx
+++ b/src/renderer/src/components/NotSupport.jsx
@@ -1,4 +1,84 @@
-function NotSupport() {
+import bcd from "@mdn/browser-compat-data";
+
+function NotSupport({ cssData, cssProperty, userSelections, browsers }) {
+  let browserCompatibilityByVersions;
+  let propertyAddedVersion;
+
+  userSelections.forEach(userSelect => {
+    browsers[userSelect.browser].versionsNotSupport = [];
+    browsers[userSelect.browser].versionsPartiallySupport = [];
+    browsers[userSelect.browser].versionsSupport = [];
+
+    if (cssData.data[cssProperty]) {
+      browserCompatibilityByVersions =
+        cssData.data[cssProperty].stats[browsers[userSelect.browser].stat];
+    } else {
+      const browserName = convertBrowserName(browsers[userSelect.browser].stat);
+
+      propertyAddedVersion =
+        bcd.css.properties[cssProperty].__compat.support[browserName]
+          .version_added;
+    }
+
+    if (browserCompatibilityByVersions) {
+      for (const version in browserCompatibilityByVersions) {
+        userSelections.forEach(userSelect => {});
+        const compatibility = browserCompatibilityByVersions[version];
+
+        if (compatibility === "n") {
+          browsers[userSelect.browser].versionsNotSupport.push(version);
+        } else if (compatibility.includes("a")) {
+          browsers[userSelect.browser].versionsPartiallySupport.push(version);
+        } else if (compatibility === "y") {
+          browsers[userSelect.browser].versionsSupport.push(version);
+        }
+      }
+
+      browsers[userSelect.browser].versionsNotSupport.sort((a, b) => a - b);
+      browsers[userSelect.browser].versionsPartiallySupport.sort(
+        (a, b) => a - b,
+      );
+      browsers[userSelectbrowser].versionsSupport.sort((a, b) => a - b);
+    } else if (propertyAddedVersion) {
+      browsers[userSelect.browser].version.forEach(versionInfo => {
+        if (Number(versionInfo.version) < Number(propertyAddedVersion)) {
+          browsers[userSelect.browser].versionsNotSupport.push(
+            versionInfo.version,
+          );
+        } else if (
+          Number(versionInfo.version) >= Number(propertyAddedVersion)
+        ) {
+          browsers[userSelect.browser].versionsSupport.push(
+            versionInfo.version,
+          );
+        }
+
+        browsers[userSelect.browser].versionsNotSupport.sort((a, b) => a - b);
+        browsers[userSelect.browser].versionsPartiallySupport.sort(
+          (a, b) => a - b,
+        );
+        browsers[userSelect.browser].versionsSupport.sort((a, b) => a - b);
+      });
+    }
+  });
+
+  function convertBrowserName(browserStat) {
+    switch (browserStat) {
+      case "samsung":
+        return "samsunginternet_android";
+      case "and_chr":
+        return "chrome_android";
+      case "android":
+        return "webview_android";
+      case "ios_saf":
+        return "safari_ios";
+      case "and_ff":
+        return "firefox_android";
+      default:
+        return browserStat;
+    }
+  }
+
   return (
     <div className="flex justify-evenly items-center flex-col mt-10 bg-red-5 w-4/5 h-80 scroll-auto">
       <h3 className="font-bold">
@@ -7,19 +87,59 @@ function NotSupport() {
       </h3>
       <div>
         <div className="flex">
-          <div>
-            <h4 className="text-2xl font-extrabold">Chrome</h4>
-            <p className="text-xs">Version</p>
-            <div className="flex justify-center items-center h-16 bg-red text-xl text-white">
-              4 - 124
-            </div>
-          </div>
-          <div className="ml-10">
-            <h4 className="text-2xl font-extrabold">FireFox</h4>
-            <p className="text-xs">Version</p>
-            <div className="flex justify-center items-center h-16 bg-red text-xl text-white">
-              2 - 125
-            </div>
+          <div className="flex flex-col">
+            {userSelections.map((selection, index) => (
+              <div key={index} className="flex justify-end w-full mt-10">
+                <div className="mx-3">
+                  <h4 className="text-2xl font-extrabold">
+                    {selection.browser}
+                  </h4>
+                  <p className="text-xs">Your version "{selection.version}"</p>
+                  <div>
+                    {browsers[selection.browser].versionsNotSupport.length !==
+                      0 && (
+                      <div className="flex flex-col justify-center items-center h-12 bg-red text-xl text-white">
+                        {browsers[selection.browser].versionsNotSupport[0]} -{" "}
+                        {
+                          browsers[selection.browser].versionsNotSupport[
+                            browsers[selection.browser].versionsNotSupport
+                              .length - 1
+                          ]
+                        }
+                      </div>
+                    )}
+                    {browsers[selection.browser].versionsPartiallySupport
+                      .length !== 0 && (
+                      <div className="flex flex-col justify-center items-center h-12 mt-3 bg-yellow text-xl text-white">
+                        {
+                          browsers[selection.browser]
+                            .versionsPartiallySupport[0]
+                        }{" "}
+                        -{" "}
+                        {
+                          browsers[selection.browser].versionsPartiallySupport[
+                            browsers[selection.browser].versionsPartiallySupport
+                              .length - 1
+                          ]
+                        }
+                      </div>
+                    )}
+                    {browsers[selection.browser].versionsSupport.length !==
+                      0 && (
+                      <div className="flex justify-center items-center h-12 mt-3 bg-green text-xl text-white">
+                        {browsers[selection.browser].versionsSupport[0]} -{" "}
+                        {
+                          browsers[selection.browser].versionsSupport[
+                            browsers[selection.browser].versionsSupport.length -
+                              1
+                          ]
+                        }
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
           <div className="mx-10 my-2 p-4 h-auto bg-red-200">
             <p>style.css in /User/Desktop/project</p>

--- a/src/renderer/src/components/Result.jsx
+++ b/src/renderer/src/components/Result.jsx
@@ -2,7 +2,7 @@ import { FaCheck } from "react-icons/fa";
 import Detail from "./Detail";
 import { useState } from "react";
 
-function Result({ isPerfect, cssInfo, userSelections }) {
+function Result({ isPerfect, cssInfo, userSelections, cssData, browsers }) {
   const notSupportedProperties = [];
   const partialSupportProperties = [];
   const [isDetailClicked, setIsDetailClicked] = useState(false);
@@ -30,6 +30,13 @@ function Result({ isPerfect, cssInfo, userSelections }) {
 
     setIsDetailClicked(true);
   }
+
+  const deduplicatedNotSupportedProperties = [
+    ...new Set(notSupportedProperties),
+  ];
+  const deduplicatedPartialSupportProperties = [
+    ...new Set(partialSupportProperties),
+  ];
 
   return (
     <>
@@ -94,7 +101,7 @@ function Result({ isPerfect, cssInfo, userSelections }) {
                 <div className="ml-14 text-xs">Not Supported</div>
                 <div className="flex items-center flex-col mb-3">
                   <form className="flex items-center w-4/5 h-16 border-2 border-red">
-                    {notSupportedProperties.map(property => {
+                    {deduplicatedNotSupportedProperties.map(property => {
                       return (
                         <button
                           key={property}
@@ -111,7 +118,7 @@ function Result({ isPerfect, cssInfo, userSelections }) {
                 <div className="ml-14 text-xs">Partial Supported</div>
                 <div className="flex items-center flex-col">
                   <form className="flex items-center w-4/5 h-16 border-2 border-yellow">
-                    {partialSupportProperties.map(property => {
+                    {deduplicatedPartialSupportProperties.map(property => {
                       return (
                         <button
                           key={property}
@@ -129,8 +136,11 @@ function Result({ isPerfect, cssInfo, userSelections }) {
             </main>
           ) : (
             <Detail
+              cssData={cssData}
               cssInfo={clickedValue}
               isNotSupportCss={isClickNotSupportCss}
+              browsers={browsers}
+              userSelections={userSelections}
             />
           )}
         </>


### PR DESCRIPTION
## 내용
- 유저가 선택한 브라우저와 버전을 보여주는 기능을 호환되지 않는 페이지에서 구현하였습니다.
<img width="1278" alt="image" src="https://github.com/TeamTitans1/checkyourcss/assets/128145017/75d7c814-43b0-4d2e-b824-26e7fc06dffb">

- 호환되지 않는 버전, 일부 호환되는 버전, 그리고 호환되는 버전을 각각 따로 나누어 결과를 도출하였습니다.
<br/>

## 변경 사항
- NotSupport.jsx에서 기능을 추가하였습니다.
<br/>

## 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
<br/>

## 참고사항
기타 참고할 사항이 있다면 여기에 기록해주세요.
<br/>

