### PR TITLE
Refactor: change the codes of getting TailwindCSS properties of projects

### DIFF
--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -10,8 +10,8 @@ if (process.contextIsolated) {
       openDirectory: () => ipcRenderer.invoke("open-directory"),
     });
     contextBridge.exposeInMainWorld("userCssDataAPI", {
-      getUserCssDataUtility: projectPath =>
-        ipcRenderer.invoke("get-utility-first-css-properties", projectPath),
+      getUserTailwindCssData: projectPath =>
+        ipcRenderer.invoke("get-tailwind-css-properties", projectPath),
       getUserCssDataStyled: projectPath =>
         ipcRenderer.invoke("get-styled-component-css-properties", projectPath),
     });

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -119,9 +119,9 @@ function Home() {
   }
 
   async function handleCheckClick() {
-    if (projectPath && userSelections) {
-      const userCssData = await (cssFrameworkType === "utility-first-css"
-        ? window.userCssDataAPI.getUserCssDataUtility(projectPath)
+    if (projectPath && userSelections && cssFrameworkType) {
+      const userCssData = await (cssFrameworkType === "tailwindCss"
+        ? window.userCssDataAPI.getUserTailwindCssData(projectPath)
         : window.userCssDataAPI.getUserCssDataStyled(projectPath));
       const result = checkCssCompatibility(userCssData);
 
@@ -270,12 +270,12 @@ function Home() {
               <input
                 type="radio"
                 name="cssType"
-                id="utility-first-css"
-                value="utility-first-css"
+                id="tailwindCss"
+                value="tailwindCss"
                 onClick={handleRadioOnClick}
               />
-              <label htmlFor="utility-first-css" className="pr-4 ">
-                Utility-first CSS
+              <label htmlFor="tailwindCss" className="pr-4 ">
+                Tailwind CSS
               </label>
               <input
                 type="radio"
@@ -284,7 +284,7 @@ function Home() {
                 value="css-in-js"
                 onClick={handleRadioOnClick}
               />
-              <label htmlFor="css-in-js">CSS-in-JS</label>
+              <label htmlFor="css-in-js">styled-components</label>
             </form>
           </div>
           <button


### PR DESCRIPTION
# 사용자 데이터에서 CSS 속성 가져오기
- https://dune-hammer-c89.notion.site/CSS-48c93c07df96445b85a0b4eb28ffad34?pvs=4

## Description
- 임의로 사용자의 프로젝트를 빌드하는 기존 방식에서 [`tailwind_to_css`](https://github.com/Devzstudio/tailwind_to_css/blob/main/cheatsheet.ts)에서 제공하는 TailwindCSS 데이터를 사용하여 CSS 속성을 가져왔습니다.
- 빌드를 하지 않기 때문에 사용자의 프로젝트가 수정할 걱정이 없고, 찾는 속도가 빨라졌습니다.
- CSS 속성을 가져오는 flow는 다음과 같습니다:
  1. `tailwind_to_css` github에서 데이터를 가져옵니다.
  2. 사용자가 제공한 프로젝트를 모두 순회하면서 TailwindCSS가 작성된 파일을 찾습니다. TailwindCSS는 html tag의 class로 작성해야 하기 때문에 `className` 또는 `class`라는 이름을 가지면 TailwindCSS가 작성되었다고 가정하였습니다.
  3. TailwindCSS의 class 명을 추출합니다. TailwindCSS 문법은 html tag 내에 존재하기 때문에 '<'로 시작하여 '>'로 끝나는 문자열을 우선 찾았습니다. 그 사이에 `"className"` 또는 `"class"`가 있고, 큰 따옴표 또는 작은 따옴표로 감싸진 문자열이 TailwindCSS의 class 명이므로 정규표현식 및 조건문을 사용하여 추출하였습니다.
  4. 3에서 추출한 class 명을 1의 데이터와 비교하여 본래의 CSS 속성을 찾아 반환합니다. 이 과정에서의 로직은 [`tailwind_to_css`](https://github.com/Devzstudio/tailwind_to_css/blob/main/libs/helpers.ts)를 일부 참조하였습니다.
 
## Focus
- 로직에 대한 예외 케이스가 있는 지 생각해주셨으면 좋겠습니다.

## Changes
- Home화면에서 CSS 프레임워크를 선택하지 않아도 비교를 시작하는 버그를 수정하였습니다.
- 기존의 `Utility-first CSS`를 통틀어 작성된 부분을 `TailwindCSS`로 수정하였습니다.

## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
