### PR TITLE
Feat: Create showing the lines of not compatible css properties

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -126,7 +126,7 @@ app.whenReady().then(() => {
   }
 
   function extractClasses(classContent) {
-    const classes = [];
+    const tailwindCssClasses = [];
     const quoteType = classContent.includes('"') ? '"' : "'";
     const startIndex = classContent.indexOf(quoteType);
     const endIndex = classContent.lastIndexOf(quoteType);
@@ -134,10 +134,10 @@ app.whenReady().then(() => {
       const classNames = classContent
         .slice(startIndex + 1, endIndex)
         .split(" ");
-      classes.push(...classNames);
+      tailwindCssClasses.push(...classNames);
     }
 
-    return classes;
+    return tailwindCssClasses;
   }
 
   function getTailwindCssClasses(files) {
@@ -155,9 +155,9 @@ app.whenReady().then(() => {
 
         fileContent.forEach(content => {
           const classContent = getClassContent(content);
-          const classes = extractClasses(classContent);
+          const tailwindCssClasses = extractClasses(classContent);
 
-          tailwindClasses.push(...classes);
+          tailwindClasses.push(...tailwindCssClasses);
         });
 
         tailwindCssInfo.push({
@@ -317,7 +317,7 @@ app.whenReady().then(() => {
     },
   );
 
-  function getAlias(files) {
+  function getStyledComponentsAlias(files) {
     const styledComponentsInfo = [];
 
     for (const filePath in files) {
@@ -368,7 +368,7 @@ app.whenReady().then(() => {
     "get-styled-components-css-properties",
     (event, directoryPath) => {
       const files = getFiles(directoryPath);
-      const styledComponentsInfo = getAlias(files);
+      const styledComponentsInfo = getStyledComponentsAlias(files);
       getUserCss(styledComponentsInfo);
 
       return styledComponentsInfo;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -79,21 +79,16 @@ app.whenReady().then(() => {
     }
   }
 
-  function getCssFiles(directoryPath) {
-    const cssFiles = [];
+  function getFiles(directoryPath) {
+    const files = {};
     const ignoredFiles = [
       "node_modules",
       "build",
       "dist",
       "out",
       ".DS_Store",
-      ".map",
-      ".md",
-      ".json",
-      ".png",
-      ".jpeg",
-      ".jpg",
-      ".gif",
+      "package.json",
+      "package-lock.json",
     ];
 
     function traverseDirectory(currentPath) {
@@ -110,21 +105,14 @@ app.whenReady().then(() => {
         if (stats.isDirectory()) {
           traverseDirectory(entryPath);
         } else if (stats.isFile()) {
-          const fileContents = readFileSync(entryPath, { encoding: "utf8" });
-
-          if (
-            fileContents.includes("className") ||
-            fileContents.includes("class")
-          ) {
-            cssFiles.push({ path: entryPath, content: fileContents });
-          }
+          files[entryPath] = readFileSync(entryPath, { encoding: "utf8" });
         }
       });
     }
 
     traverseDirectory(directoryPath);
 
-    return cssFiles;
+    return files;
   }
 
   function getClassContent(content) {
@@ -142,7 +130,6 @@ app.whenReady().then(() => {
     const quoteType = classContent.includes('"') ? '"' : "'";
     const startIndex = classContent.indexOf(quoteType);
     const endIndex = classContent.lastIndexOf(quoteType);
-
     if (startIndex !== -1 && endIndex !== -1) {
       const classNames = classContent
         .slice(startIndex + 1, endIndex)
@@ -153,21 +140,35 @@ app.whenReady().then(() => {
     return classes;
   }
 
-  function getTailwindCssClasses(cssFiles) {
-    const tailwindCssClasses = [];
+  function getTailwindCssClasses(files) {
+    const tailwindCssInfo = [];
 
-    cssFiles.forEach(file => {
-      const fileContent = file.content.replace(/\n/g, "").match(/<([^>]*)>/g);
+    for (const filePath in files) {
+      if (
+        files[filePath].includes("className") ||
+        files[filePath].includes("class")
+      ) {
+        const fileContent = files[filePath]
+          .replace(/\n/g, "")
+          .match(/<([^>]*)>/g);
+        const tailwindClasses = [];
 
-      fileContent.forEach(content => {
-        const classContent = getClassContent(content);
-        const classes = extractClasses(classContent);
+        fileContent.forEach(content => {
+          const classContent = getClassContent(content);
+          const classes = extractClasses(classContent);
 
-        tailwindCssClasses.push(...classes);
-      });
-    });
+          tailwindClasses.push(...classes);
+        });
 
-    return [...new Set(tailwindCssClasses)];
+        tailwindCssInfo.push({
+          filePath,
+          content: files[filePath],
+          tailwindClasses: [...new Set(tailwindClasses)],
+        });
+      }
+    }
+
+    return tailwindCssInfo;
   }
 
   function compareCssClasses(tailwindCssData, cssClass) {
@@ -214,8 +215,7 @@ app.whenReady().then(() => {
       .map(i => i.replace("hover:", ""));
   }
 
-  function getCssProperties(tailwindCssData, tailwindCssClasses) {
-    const cssProperties = [];
+  function getCssProperties(tailwindCssData, tailwindCssInfo) {
     const exceptionalSupportedTailwindCssClasses = {
       pt: "padding-top",
       pb: "padding-bottom",
@@ -242,143 +242,138 @@ app.whenReady().then(() => {
       "max-h": "max-height",
     };
 
-    tailwindCssClasses.forEach(cssClass => {
-      cssProperties.push(...compareCssClasses(tailwindCssData, cssClass));
-      if (cssClass.includes("hover")) {
-        const hoverClass = getHoverClass(cssClass);
+    tailwindCssInfo.forEach(info => {
+      info.cssMatching = {};
 
-        cssProperties.push(
-          ...compareCssClasses(tailwindCssData, hoverClass[0]),
-        );
-      }
-    });
+      info.tailwindClasses.forEach(tailwindClass => {
+        const cssClasses = [
+          ...new Set(compareCssClasses(tailwindCssData, tailwindClass)),
+        ];
 
-    const exceptionalClasses = tailwindCssClasses.filter(className =>
-      className.includes("["),
-    );
+        cssClasses.forEach(cssClass => {
+          if (Object.keys(info.cssMatching).includes(cssClass)) {
+            info.cssMatching[cssClass].push(tailwindClass);
+          } else {
+            info.cssMatching[cssClass] = [];
+            info.cssMatching[cssClass].push(tailwindClass);
+          }
+        });
 
-    if (exceptionalClasses) {
-      exceptionalClasses.forEach(className => {
-        const property = className.split("-[")[0].replace(".", "");
+        if (tailwindClass.includes("hover")) {
+          const hoverClass = getHoverClass(tailwindClass);
+          const cssClasses = [
+            ...new Set(compareCssClasses(tailwindCssData, hoverClass[0])),
+          ];
 
-        if (exceptionalSupportedTailwindCssClasses[property]) {
-          cssProperties.push(exceptionalSupportedTailwindCssClasses[property]);
+          cssClasses.forEach(cssClass => {
+            if (Object.keys(info.cssMatching).includes(cssClass)) {
+              info.cssMatching[cssClass].push(tailwindClass);
+            } else {
+              info.cssMatching[cssClass] = [];
+              info.cssMatching[cssClass].push(tailwindClass);
+            }
+          });
         }
       });
-    }
 
-    return [...new Set(cssProperties)];
+      const exceptionalClasses = info.tailwindClasses.filter(className =>
+        className.includes("["),
+      );
+
+      if (exceptionalClasses) {
+        exceptionalClasses.forEach(className => {
+          const property = className.split("-[")[0].replace(".", "");
+
+          if (
+            Object.keys(info.cssMatching).includes(
+              exceptionalSupportedTailwindCssClasses[property],
+            )
+          ) {
+            info.cssMatching[
+              exceptionalSupportedTailwindCssClasses[property]
+            ].push(className);
+          } else {
+            info.cssMatching[exceptionalSupportedTailwindCssClasses[property]] =
+              [];
+            info.cssMatching[
+              exceptionalSupportedTailwindCssClasses[property]
+            ].push(className);
+          }
+        });
+      }
+    });
   }
 
   ipcMain.handle(
     "get-tailwind-css-properties",
     async (event, directoryPath) => {
-      try {
-        const tailwindCssData = await getTailwindCssData();
-        const cssFiles = getCssFiles(directoryPath);
-        const tailwindCssClasses = getTailwindCssClasses(cssFiles);
-        const cssProperties = getCssProperties(
-          tailwindCssData,
-          tailwindCssClasses,
-        );
+      const tailwindCssData = await getTailwindCssData();
+      const files = getFiles(directoryPath);
+      const tailwindCssInfo = getTailwindCssClasses(files);
 
-        return cssProperties;
-      } catch (err) {
-        console.error(err);
-      }
+      getCssProperties(tailwindCssData, tailwindCssInfo);
+
+      return tailwindCssInfo;
     },
   );
 
-  ipcMain.handle("get-styled-component-css-properties", (event, args) => {
-    const directoryPath = args;
-    const info = {};
+  function getAlias(files) {
+    const styledComponentsInfo = [];
 
-    function getAllFiles(directoryPath) {
-      const files = readdirSync(directoryPath);
+    for (const filePath in files) {
+      if (files[filePath].includes("styled-components")) {
+        const fileSplits = files[filePath].split("\n");
+        const regex = /from ['"]styled-components['"];/g;
+        const index = fileSplits.findIndex(line => line.match(regex));
 
-      files.forEach(file => {
-        if (
-          file === "node_modules" ||
-          file.includes(".map") ||
-          file.endsWith(".md") ||
-          file.endsWith(".json")
-        ) {
-          return;
-        }
+        const alias = fileSplits[index]
+          .replace(/["']styled-components["']|;|{|}|import|require|from/g, "")
+          .trim();
 
-        const fullPath = path.join(directoryPath, file);
-        const stats = statSync(fullPath);
-
-        if (stats.isFile()) {
-          info[fullPath] = readFileSync(fullPath, { encoding: "utf8" });
-        } else if (stats.isDirectory()) {
-          getAllFiles(fullPath);
-        }
-      });
-    }
-
-    function getAliasAndContentInfo() {
-      const aliasAndContentInfo = [];
-
-      for (const filePath in info) {
-        if (info[filePath].includes("styled-components")) {
-          const fileSplits = info[filePath].split("\n");
-          let index = fileSplits.findIndex(line =>
-            line.includes('from "styled-components";'),
-          );
-
-          const alias = fileSplits[index]
-            .replace(
-              /"styled-components"|;|import|{|}|require|import|const|let|var|=|from/g,
-              "",
-            )
-            .trim();
-
-          aliasAndContentInfo.push({
-            alias,
-            filePath,
-            fileContent: info[filePath],
-          });
-        }
+        styledComponentsInfo.push({
+          alias,
+          filePath,
+          fileContent: files[filePath],
+        });
       }
-
-      return aliasAndContentInfo;
     }
 
-    function getUserCssStrings(file) {
-      const userCss = [];
-      const cssStrings = file.fileContent.split("\n");
+    return styledComponentsInfo;
+  }
+
+  function getUserCss(styledComponentsInfo) {
+    const userCss = [];
+
+    styledComponentsInfo.forEach(info => {
+      const fileContent = info.fileContent.split("\n");
       let isStart = false;
 
-      cssStrings.forEach(cssString => {
-        if (cssString.includes("import") || cssString.includes("require")) {
+      fileContent.forEach(content => {
+        if (content.includes("import") || content.includes("require")) {
           return;
-        } else if (cssString.includes(file.alias)) {
+        } else if (content.includes(info.alias)) {
           isStart = true;
-        } else if (
-          isStart &&
-          cssString.includes(":") &&
-          cssString.includes(";")
-        ) {
-          userCss.push(cssString.split(":")[0].trim());
-        } else if (cssString.includes("`;")) {
+        } else if (isStart && content.includes(":") && content.includes(";")) {
+          userCss.push(content.split(":")[0].trim());
+        } else if (content.includes("`")) {
           isStart = false;
         }
       });
 
-      return userCss;
-    }
+      info.cssProperties = [...new Set(userCss)];
+    });
+  }
 
-    getAllFiles(directoryPath);
+  ipcMain.handle(
+    "get-styled-components-css-properties",
+    (event, directoryPath) => {
+      const files = getFiles(directoryPath);
+      const styledComponentsInfo = getAlias(files);
+      getUserCss(styledComponentsInfo);
 
-    const aliasAndContentInfo = getAliasAndContentInfo();
-    const userCss = aliasAndContentInfo.flatMap(file =>
-      getUserCssStrings(file),
-    );
-    const finalCss = [...new Set(userCss)];
-
-    return finalCss;
-  });
+      return styledComponentsInfo;
+    },
+  );
 
   app.on("activate", function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -10,10 +10,10 @@ if (process.contextIsolated) {
       openDirectory: () => ipcRenderer.invoke("open-directory"),
     });
     contextBridge.exposeInMainWorld("userCssDataAPI", {
-      getUserTailwindCssData: projectPath =>
+      getTailwindCssData: projectPath =>
         ipcRenderer.invoke("get-tailwind-css-properties", projectPath),
-      getUserCssDataStyled: projectPath =>
-        ipcRenderer.invoke("get-styled-component-css-properties", projectPath),
+      getStyledComponentsData: projectPath =>
+        ipcRenderer.invoke("get-styled-components-css-properties", projectPath),
     });
   } catch (error) {
     console.error(error);

--- a/src/renderer/src/components/Detail.jsx
+++ b/src/renderer/src/components/Detail.jsx
@@ -5,11 +5,12 @@ import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 
 function Detail({
   cssData,
-  cssInfo,
+  clickedValue,
   isNotSupportCss,
-  userSelections,
   browsers,
+  userSelections,
   setIsDetailClicked,
+  cssInfo,
 }) {
   function handleGoBackClick() {
     setIsDetailClicked(false);
@@ -24,16 +25,18 @@ function Detail({
       {isNotSupportCss ? (
         <NotSupport
           cssData={cssData}
-          cssProperty={cssInfo}
+          cssProperty={clickedValue}
           userSelections={userSelections}
           browsers={browsers}
+          cssInfo={cssInfo}
         />
       ) : (
         <PartialSupport
           cssData={cssData}
-          cssProperty={cssInfo}
+          cssProperty={clickedValue}
           userSelections={userSelections}
           browsers={browsers}
+          cssInfo={cssInfo}
         />
       )}
       <button className="mb-24 px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black">

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -13,6 +13,7 @@ function Home() {
   const [projectPath, setProjectPath] = useState("");
   const [cssCompatibilityResult, setCssCompatibilityResult] = useState(null);
   const [isAllCompatible, setIsAllCompatible] = useState(true);
+  const [cssInfo, setCssInfo] = useState(null);
 
   useEffect(() => {
     async function getData() {
@@ -121,11 +122,12 @@ function Home() {
   async function handleCheckClick() {
     if (projectPath && userSelections && cssFrameworkType) {
       const userCssData = await (cssFrameworkType === "tailwindCss"
-        ? window.userCssDataAPI.getUserTailwindCssData(projectPath)
-        : window.userCssDataAPI.getUserCssDataStyled(projectPath));
-      const result = checkCssCompatibility(userCssData);
+        ? window.userCssDataAPI.getTailwindCssData(projectPath)
+        : window.userCssDataAPI.getStyledComponentsData(projectPath));
 
-      setCssCompatibilityResult(checkCssCompatibility(userCssData));
+      const result = checkCssCompatibility(userCssData);
+      setCssInfo(userCssData);
+      setCssCompatibilityResult(result);
 
       result.forEach(property => {
         if (property.compatibility !== "y") {
@@ -136,9 +138,20 @@ function Home() {
   }
 
   function checkCssCompatibility(userCssData) {
+    const userCss = [];
     const result = [];
 
-    userCssData.forEach(property => {
+    if (userCssData.cssProperties) {
+      userCssData.forEach(data => {
+        userCss.push(...data.cssProperties);
+      });
+    } else {
+      userCssData.forEach(data => {
+        userCss.push(...Object.keys(data.cssMatching));
+      });
+    }
+
+    userCss.forEach(property => {
       if (property in fullData.data) {
         userSelections.forEach(selection => {
           const stat = browsers[selection.browser].stat;
@@ -297,10 +310,11 @@ function Home() {
       ) : (
         <Result
           isPerfect={isAllCompatible}
-          cssInfo={cssCompatibilityResult}
+          cssInfo={cssInfo}
           userSelections={userSelections}
           cssData={fullData}
           browsers={browsers}
+          cssCompatibilityResult={cssCompatibilityResult}
         />
       )}
     </>

--- a/src/renderer/src/components/Result.jsx
+++ b/src/renderer/src/components/Result.jsx
@@ -2,14 +2,21 @@ import { FaCheck } from "react-icons/fa";
 import Detail from "./Detail";
 import { useState } from "react";
 
-function Result({ isPerfect, cssInfo, userSelections, cssData, browsers }) {
+function Result({
+  isPerfect,
+  cssInfo,
+  userSelections,
+  cssData,
+  browsers,
+  cssCompatibilityResult,
+}) {
   const notSupportedProperties = [];
   const partialSupportProperties = [];
   const [isDetailClicked, setIsDetailClicked] = useState(false);
   const [isClickNotSupportCss, setIsClickNotSupportCss] = useState(true);
   const [clickedValue, setClickedValue] = useState("");
 
-  cssInfo.forEach(item => {
+  cssCompatibilityResult.forEach(item => {
     if (item.compatibility === "n") {
       notSupportedProperties.push(item.property);
     }
@@ -86,13 +93,13 @@ function Result({ isPerfect, cssInfo, userSelections, cssData, browsers }) {
               <div className="flex justify-evenly h-96 w-4/5 mb-2">
                 <div className="flex items-center flex-col m-10">
                   <div className="flex justify-center items-center border-8 w-24 h-24 border-red rounded-full mb-2 text-4xl">
-                    {notSupportedProperties.length}
+                    {deduplicatedNotSupportedProperties.length}
                   </div>
                   <div>Not Supported</div>
                 </div>
                 <div className="flex items-center flex-col m-10">
                   <div className="flex justify-center items-center border-8 w-24 h-24 border-yellow rounded-full mb-2 text-4xl">
-                    {partialSupportProperties.length}
+                    {deduplicatedPartialSupportProperties.length}
                   </div>
                   <div>Partial Supported</div>
                 </div>
@@ -137,11 +144,12 @@ function Result({ isPerfect, cssInfo, userSelections, cssData, browsers }) {
           ) : (
             <Detail
               cssData={cssData}
-              cssInfo={clickedValue}
+              clickedValue={clickedValue}
               isNotSupportCss={isClickNotSupportCss}
               browsers={browsers}
               userSelections={userSelections}
               setIsDetailClicked={setIsDetailClicked}
+              cssInfo={cssInfo}
             />
           )}
         </>

--- a/src/renderer/src/main.jsx
+++ b/src/renderer/src/main.jsx
@@ -12,6 +12,6 @@ const router = createBrowserRouter([
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <RouterProvider router={router} />,
   </React.StrictMode>,
 );


### PR DESCRIPTION
# 호환되지 않는 CSS 속성 코드 보여주기
- https://dune-hammer-c89.notion.site/CSS-d2d11c99db944c3bbbce7d0349b4d8b7?pvs=4

## Description
- TailwindCSS와 styled-components를 구현하는 과정은 약간만 다를 뿐, 거의 동일한 코드를 가집니다.
- 코드가 몇 번줄에 있는 지를 보여주기 위해서 해당 파일의 내용을 담아 React로 보냅니다.
- 그렇게 보낸 내용을 `\n`으로 나누어 사용자가 선택한 CSS property와 일치되는 부분을 찾았습니다. 일치된 부분의 `index + 1`이 실제 코드에서 줄이므로 그 값을 반환하였습니다.

## Focus
- 제 로직이 맞는지, 틀린점은 없는지 확인해주셨으면 합니다.

## Etc
<img width="1435" alt="image" src="https://github.com/TeamTitans1/checkyourcss/assets/128145017/ea09927b-a742-46ec-8d52-1e83960c4bd0">


## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
