### PR TITLE
Refactor: Change Go to Your Code button enable

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,6 +3,7 @@ import path, { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import axios from "axios";
 import { readdirSync, statSync, readFileSync } from "fs";
+import { execSync } from "child_process";
 
 function createWindow() {
   const mainWindow = new BrowserWindow({
@@ -374,6 +375,20 @@ app.whenReady().then(() => {
       return styledComponentsInfo;
     },
   );
+
+  ipcMain.handle("open-files", (event, propertyInfo) => {
+    const filePaths = [];
+
+    propertyInfo.forEach(info => {
+      filePaths.push(info.path);
+    });
+
+    const openingPaths = [...new Set(filePaths)];
+
+    openingPaths.forEach(path => {
+      execSync(`open ${path}`);
+    });
+  });
 
   app.on("activate", function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -8,6 +8,7 @@ if (process.contextIsolated) {
     });
     contextBridge.exposeInMainWorld("loadProjectAPI", {
       openDirectory: () => ipcRenderer.invoke("open-directory"),
+      openFiles: propertyInfo => ipcRenderer.invoke("open-files", propertyInfo),
     });
     contextBridge.exposeInMainWorld("userCssDataAPI", {
       getTailwindCssData: projectPath =>

--- a/src/renderer/src/components/Detail.jsx
+++ b/src/renderer/src/components/Detail.jsx
@@ -39,9 +39,6 @@ function Detail({
           cssInfo={cssInfo}
         />
       )}
-      <button className="mb-24 px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black">
-        Go to Your Code!
-      </button>
     </section>
   );
 }

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -168,7 +168,7 @@ function Home() {
             typeof selection.version === "string" &&
             selection.version.includes("-")
           ) {
-            const versionRangeToversion = convertToNumberWithOneDecimal(
+            const versionRangeToVersion = convertToNumberWithOneDecimal(
               selection.version,
             );
             const browserName = convertBrowserName(
@@ -177,8 +177,8 @@ function Home() {
             const stat =
               bcd.css.properties[property].__compat.support[browserName];
             const isCompatible = Array.isArray(stat)
-              ? parseInt(stat[0].version_added) <= versionRangeToversion
-              : parseInt(stat.version_added) <= versionRangeToversion;
+              ? parseInt(stat[0].version_added) <= versionRangeToVersion
+              : parseInt(stat.version_added) <= versionRangeToVersion;
 
             result.push({
               property,

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -164,19 +164,41 @@ function Home() {
         });
       } else if (property in bcd.css.properties) {
         userSelections.forEach(selection => {
-          const browserName = convertBrowserName(
-            browsers[selection.browser].stat,
-          );
-          const stat =
-            bcd.css.properties[property].__compat.support[browserName];
-          const isCompatible = Array.isArray(stat)
-            ? parseInt(stat[0].version_added) <= selection.version
-            : parseInt(stat.version_added) <= selection.version;
+          if (
+            typeof selection.version === "string" &&
+            selection.version.includes("-")
+          ) {
+            const versionRangeToversion = convertToNumberWithOneDecimal(
+              selection.version,
+            );
+            const browserName = convertBrowserName(
+              browsers[selection.browser].stat,
+            );
+            const stat =
+              bcd.css.properties[property].__compat.support[browserName];
+            const isCompatible = Array.isArray(stat)
+              ? parseInt(stat[0].version_added) <= versionRangeToversion
+              : parseInt(stat.version_added) <= versionRangeToversion;
 
-          result.push({
-            property,
-            compatibility: isCompatible ? "y" : "n",
-          });
+            result.push({
+              property,
+              compatibility: isCompatible ? "y" : "n",
+            });
+          } else {
+            const browserName = convertBrowserName(
+              browsers[selection.browser].stat,
+            );
+            const stat =
+              bcd.css.properties[property].__compat.support[browserName];
+            const isCompatible = Array.isArray(stat)
+              ? parseInt(stat[0].version_added) <= selection.version
+              : parseInt(stat.version_added) <= selection.version;
+
+            result.push({
+              property,
+              compatibility: isCompatible ? "y" : "n",
+            });
+          }
         });
       }
     });

--- a/src/renderer/src/components/NotSupport.jsx
+++ b/src/renderer/src/components/NotSupport.jsx
@@ -139,6 +139,10 @@ function NotSupport({
     });
   }
 
+  async function handleGoToYourCodeClick() {
+    await window.loadProjectAPI.openFiles(propertyInfo);
+  }
+
   return (
     <div className="flex flex-col justify-center items-center mb-10">
       <h3 className="text-3xl font-bold">
@@ -146,7 +150,7 @@ function NotSupport({
         supported.
       </h3>
       <div>
-        <div>
+        <div className="flex flex-col justify-center items-center w-full">
           <div className="flex justify-center items-center mb-10">
             {userSelections.map((selection, index) => (
               <div
@@ -245,6 +249,12 @@ function NotSupport({
               );
             })}
           </div>
+          <button
+            onClick={handleGoToYourCodeClick}
+            className="m-12 px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black"
+          >
+            Go to Your Code!
+          </button>
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/PartialSupport.jsx
+++ b/src/renderer/src/components/PartialSupport.jsx
@@ -241,7 +241,7 @@ function PartialSupport({
           </div>
           <button
             onClick={handleGoToYourCodeClick}
-            className="m-12  px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black"
+            className="m-12 px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black"
           >
             Go to Your Code!
           </button>

--- a/src/renderer/src/components/PartialSupport.jsx
+++ b/src/renderer/src/components/PartialSupport.jsx
@@ -97,6 +97,10 @@ function PartialSupport({
     });
   }
 
+  async function handleGoToYourCodeClick() {
+    await window.loadProjectAPI.openFiles(propertyInfo);
+  }
+
   return (
     <div className="flex flex-col justify-center items-center">
       <h3 className="text-3xl font-bold">
@@ -235,6 +239,12 @@ function PartialSupport({
               </div>
             ))}
           </div>
+          <button
+            onClick={handleGoToYourCodeClick}
+            className="m-12  px-6 py-2 rounded-xl bg-black text-lg text-white font-bold hover:bg-gray hover:text-black"
+          >
+            Go to Your Code!
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Title
- [호환되지 않는 CSS속성 파일 열기](https://dune-hammer-c89.notion.site/CSS-f119297225964345b92f9692f73dbb20?pvs=4)
- [일부 호환되는 CSS속성 파일 열기](https://dune-hammer-c89.notion.site/CSS-1bace698480d42a2a518248dfeba0082?pvs=4)

## Description
1. 버튼을 클릭하게 되면 `handleGoToYourCodeClick`함수가 실행되는데 함수가 실행되게 됩니다.
2. 위의 함수내에서 window.loadProjectAPI.openFiles 함수를 호출합니다.
3. 메인 프로세스에서 openFiles 함수가 실행되고 child_process의 execSync를 사용하여 해당 파일을 열도록 합니다.

## Focus
- 열어야 하는 파일이 여러개일 경우 겹치는 경우 없이 코드를 이어 작성해야 합니다.

## Changes (Optional)
- 기존에는 버튼 모양만 있었는데 버튼이 활성화 되도록 코드를 수정하였습니다.


## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
