### PR TITLE
Refactor: Fix version compatibility errors for CSS properties

### DIFF
--- a/src/renderer/src/components/NotSupport.jsx
+++ b/src/renderer/src/components/NotSupport.jsx
@@ -18,12 +18,14 @@ function NotSupport({
     if (cssData.data[cssProperty]) {
       browserCompatibilityByVersions =
         cssData.data[cssProperty].stats[browsers[userSelect.browser].stat];
-    } else {
+    } else if (bcd.css.properties[cssProperty]) {
       const browserName = convertBrowserName(browsers[userSelect.browser].stat);
+      const stat =
+        bcd.css.properties[cssProperty].__compat.support[browserName];
 
-      propertyAddedVersion =
-        bcd.css.properties[cssProperty].__compat.support[browserName]
-          .version_added;
+      propertyAddedVersion = Array.isArray(stat)
+        ? parseInt(stat[0].version_added)
+        : parseInt(stat.version_added);
     }
 
     if (browserCompatibilityByVersions) {
@@ -207,40 +209,28 @@ function NotSupport({
           <div className="flex flex-col">
             {propertyInfo.map(info => {
               return (
-                <div className="mx-10 my-2 p-4 h-auto bg-red-200">
-                  <p className="font-bold">{info.path}</p>
-                  <p>
-                    {info.lines.map((line, index) => {
-                      if (index === 0) {
-                        return (
-                          <>
-                            <span>{`line ${line + 1}, `}</span>
-                            <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
-                              {`${line + 1} ${info.contents[line]}`}
-                            </pre>
-                          </>
-                        );
-                      } else if (info.lines.length - 1 === index) {
-                        return (
-                          <>
-                            <span>{`${line + 1}`}</span>
-                            <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
-                              {`${line + 1} ${info.contents[line]}`}
-                            </pre>
-                          </>
-                        );
-                      } else {
-                        return (
-                          <>
-                            <span>{`${line + 1}, `}</span>
-                            <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
-                              {`${line + 1} ${info.contents[line]}`}
-                            </pre>
-                          </>
-                        );
-                      }
+                <div>
+                  <div className="mx-10 my-2 p-4 h-auto bg-red-200">
+                    <p className="font-bold">{info.path}</p>
+                    <p>
+                      {info.lines.map((line, index) => {
+                        if (index === 0) {
+                          return <span>{`line ${line + 1}, `}</span>;
+                        } else if (info.lines.length - 1 === index) {
+                          return <span>{`${line + 1}`}</span>;
+                        } else {
+                          return <span>{`${line + 1}, `}</span>;
+                        }
+                      })}
+                    </p>
+                    {info.lines.map(number => {
+                      return (
+                        <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
+                          {`${number + 1} ${info.contents[number]}`}
+                        </pre>
+                      );
                     })}
-                  </p>
+                  </div>
                 </div>
               );
             })}

--- a/src/renderer/src/components/PartialSupport.jsx
+++ b/src/renderer/src/components/PartialSupport.jsx
@@ -110,47 +110,6 @@ function PartialSupport({
               <>
                 <p className="font-bold">{info.path}</p>
                 <p>
-                  {info.lines.map((line, index) => {
-                    if (index === 0) {
-                      return (
-                        <>
-                          <span>{`line ${line + 1}, `}</span>
-                          <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
-                            {`${line + 1} ${info.contents[line]}`}
-                          </pre>
-                        </>
-                      );
-                    } else if (info.lines.length - 1 === index) {
-                      return (
-                        <>
-                          <span>{`${line + 1}`}</span>
-                          <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
-                            {`${line + 1} ${info.contents[line]}`}
-                          </pre>
-                        </>
-                      );
-                    } else {
-                      return (
-                        <>
-                          <span>{`${line + 1}, `}</span>
-                          <pre className="whitespace-normal m-3 px-5 py-3 bg-black text-white">
-                            {`${line + 1} ${info.contents[line]}`}
-                          </pre>
-                        </>
-                      );
-                    }
-                  })}
-                </p>
-              </>
-            );
-          })}
-        </div>
-        <div className="mx-5 my-2 p-4 h-auto bg-yellow-200">
-          {propertyInfo.map(info => {
-            return (
-              <>
-                <p className="font-bold">{info.path}</p>
-                <p>
                   {" "}
                   {info.lines.map((line, index) => {
                     if (index === 0) {


### PR DESCRIPTION
# Title
- 호환성을 확인하는 버전의 에러 수정 및 컴포넌트의 구성 변경

## Description
- 버전 정보를 갖고 있는 데이터의 버전 정보에 접근하려면 bcd.css.properties[해당 속성].__compat.support[해당 브라우저]로 해야하는데 
bcd.css.properties[해당 속성].__compat.support[해당 브라우저]가 배열인 경우와 바로 버전에 접근이 가능한 경우로 나누어져 두 경우를 나눠서 확인하는 로직을 작성하였습니다.
- PartialSupport 컴포넌트에서 해당 css가 사용된 파일 주소와 줄을 표시하는 코드가 중복된 것이 있어 삭제 하였습니다.
- 사용된 css의 파일 주소와 줄을 표시하는 코드를 간결히 변경하였습니다

## 변경사항
- 사용된 css의 파일 주소와 줄을 표시하는 코드를 간결히 변경하였습니다.

## Focus
- 데이터 구조에 다른 특이사항이 있다면 알려주시길 바랍니다.

## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
