### PR TITLE
Feat: refactor getting tailwindcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "react-router-dom": "^6.21.3"
       },
       "devDependencies": {
+        "@babel/parser": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
         "@electron-toolkit/eslint-config": "^1.0.2",
         "@electron-toolkit/eslint-config-prettier": "^2.0.0",
         "@vitejs/plugin-react": "^4.2.1",
@@ -37,7 +39,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^9.0.6",
         "lint-staged": "^15.2.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.35",
         "prettier": "^3.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7315,9 +7317,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.33",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "react-router-dom": "^6.21.3"
   },
   "devDependencies": {
+    "@babel/parser": "^7.23.9",
+    "@babel/traverse": "^7.23.9",
     "@electron-toolkit/eslint-config": "^1.0.2",
     "@electron-toolkit/eslint-config-prettier": "^2.0.0",
     "@vitejs/plugin-react": "^4.2.1",
@@ -44,7 +46,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^9.0.6",
     "lint-staged": "^15.2.0",
-    "postcss": "^8.4.33",
+    "postcss": "^8.4.35",
     "prettier": "^3.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,14 +1,13 @@
-import { app, shell, BrowserWindow, ipcMain, dialog } from "electron";
-import path, { join } from "path";
-import { electronApp, optimizer, is } from "@electron-toolkit/utils";
-import axios from "axios";
-import { readdirSync, statSync, readFileSync } from "fs";
-import { execSync } from "child_process";
 import os from "os";
 import fs from "fs";
+import axios from "axios";
 import postcss from "postcss";
 import traverse from "@babel/traverse";
+import path, { join } from "path";
 import { parse } from "@babel/parser";
+import { execSync } from "child_process";
+import { electronApp, optimizer, is } from "@electron-toolkit/utils";
+import { app, shell, BrowserWindow, ipcMain, dialog } from "electron";
 
 function createWindow() {
   const mainWindow = new BrowserWindow({
@@ -109,16 +108,16 @@ app.whenReady().then(() => {
     return path.join(directoryPath, buildDirectory);
   }
 
-  function traverseDirectory(directoryPath, callback) {
+  function traverseDirectory(directoryPath, checkCssFile) {
     const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(directoryPath, entry.name);
 
       if (entry.isDirectory()) {
-        traverseDirectory(fullPath, callback);
+        traverseDirectory(fullPath, checkCssFile);
       } else {
-        callback(fullPath);
+        checkCssFile(fullPath);
       }
     }
   }
@@ -167,7 +166,7 @@ app.whenReady().then(() => {
     const fileContent = fs.readFileSync(filePath, "utf-8");
 
     return parse(fileContent, {
-      sourceType: "module",
+      sourceType: "unambiguous",
       plugins: ["jsx", "typescript"],
     });
   }

--- a/src/renderer/src/components/Home.jsx
+++ b/src/renderer/src/components/Home.jsx
@@ -124,8 +124,8 @@ function Home() {
       const userCssData = await (cssFrameworkType === "tailwindCss"
         ? window.userCssDataAPI.getTailwindCssData(projectPath)
         : window.userCssDataAPI.getStyledComponentsData(projectPath));
-
       const result = checkCssCompatibility(userCssData);
+
       setCssInfo(userCssData);
       setCssCompatibilityResult(result);
 


### PR DESCRIPTION
# TailwindCSS 가져오는 방식 변환

## Description
- 기존의 'tailwind_to_css' 데이터를 사용하는 방식이 아닌 build를 통해 가져오는 방법으로 전환하였습니다.
- build는 사용자의 프로젝트를 `tmpdir()`을 통해 임시 디렉토리 경로를 가져와 복제하여 진행하였습니다.
- TailwindCSS를 가져오는 방식에도 로직을 변경하였습니다. AST를 통해 Tailwind Class를 가져왔고, postcss를 사용하여 CSS 속성으로 변환하였습니다.
  - postcss를 사용한 이유는 이전에 문자열을 통해 하드 코딩을 진행했을 시 생기는 예외 케이스들과 정확도가 떨어졌기 때문입니다. PostCSS는 Tailwind CSS를 변환해주는데 그 중 walkDecls() 메서드는 PostCSS 트리의 선언(속성과 값) 노드만을 대상으로 순회합니다. 따라서 노드를 순회하면서 모든 CSS 속성을 가져올 수 있었습니다.
  - AST를 사용함에 따라 정확성과 효율성을 높였습니다. AST를 통해 코드 구조를 파악하고, CSS 클래스를 포함하는 요소를 정밀하게 식별하였습니다.

## Focus
- 기존 삭제된 코드가 많아 복잡해 보일 수 도 있습니다. 실수한 부분이 있는지 잘 확인해주시길 바랍니다.

## Checklists
- [X] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [X] 코드 스타일을 잘 확인했는가?
