### PR TITLE
Feat: refactor getting styled-components

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -373,6 +373,7 @@ app.whenReady().then(() => {
 
   function getStyledComponentsCss(directoryPath, styledComponentsCss) {
     const filesInDirectory = fs.readdirSync(directoryPath);
+
     for (const file of filesInDirectory) {
       if (
         file === "node_modules" ||

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -267,61 +267,166 @@ app.whenReady().then(() => {
     },
   );
 
-  function getStyledComponentsAlias(files) {
-    const styledComponentsInfo = [];
+  function findStyledVariableNames(fileContents) {
+    const ast = parse(fileContents, {
+      sourceType: "unambiguous",
+      plugins: ["jsx", "typescript"],
+    });
+    const imports = [];
 
-    for (const filePath in files) {
-      if (files[filePath].includes("styled-components")) {
-        const fileSplits = files[filePath].split("\n");
-        const regex = /from ['"]styled-components['"];/g;
-        const index = fileSplits.findIndex(line => line.match(regex));
+    traverse(ast, {
+      ImportDeclaration(path) {
+        if (path.node.source.value === "styled-components") {
+          path.node.specifiers.forEach(specifier => {
+            if (specifier.type === "ImportDefaultSpecifier") {
+              imports.push(specifier.local.name);
+            } else if (specifier.type === "ImportSpecifier") {
+              imports.push(specifier.imported.name);
+            }
+          });
+        }
+      },
+      VariableDeclarator(path) {
+        if (
+          path.node.init &&
+          path.node.init.callee &&
+          path.node.init.callee.name === "require" &&
+          path.node.init.arguments &&
+          path.node.init.arguments.length > 0 &&
+          path.node.init.arguments[0].value === "styled-components"
+        ) {
+          imports.push(path.node.id.name);
+        }
+      },
+    });
 
-        const alias = fileSplits[index]
-          .replace(/["']styled-components["']|;|{|}|import|require|from/g, "")
-          .trim();
+    return imports;
+  }
 
-        styledComponentsInfo.push({
-          alias,
-          filePath,
-          fileContent: files[filePath],
-        });
+  function extractStyledComponentsCSS(fileContents, styledVariableNames) {
+    if (!styledVariableNames) {
+      return;
+    }
+
+    const ast = parse(fileContents, {
+      sourceType: "unambiguous",
+      plugins: ["jsx", "typescript"],
+    });
+
+    const cssProperties = new Set();
+
+    styledVariableNames.forEach(styledVariableName => {
+      traverse(ast, {
+        TaggedTemplateExpression(path) {
+          const tagPath = path.get("tag");
+
+          if (tagPath.isCallExpression()) {
+            const calleeName = tagPath.get("callee").node.name;
+
+            if (styledVariableName.includes(calleeName)) {
+              extractCSSProperties(path, cssProperties);
+            }
+          } else if (
+            tagPath.isMemberExpression() &&
+            tagPath.get("object").node.name &&
+            styledVariableName.includes(tagPath.get("object").node.name)
+          ) {
+            extractCSSProperties(path, cssProperties);
+          } else if (
+            tagPath.isIdentifier() &&
+            styledVariableName.includes(tagPath.node.name)
+          ) {
+            extractCSSProperties(path, cssProperties);
+          }
+        },
+      });
+    });
+
+    return Array.from(cssProperties);
+  }
+
+  function extractCSSProperties(path, cssProperties) {
+    path
+      .get("quasi")
+      .get("quasis")
+      .forEach(quasiPath => {
+        const cssText = quasiPath.node.value.raw;
+        const startLine = quasiPath.node.loc.start.line;
+        const regex = /(\w+-?\w+)\s*:/g;
+        let match;
+
+        while ((match = regex.exec(cssText))) {
+          const property = match[1];
+          const lineOffset = calculateLineOffset(
+            cssText.substring(0, match.index),
+          );
+          const propertyLine = startLine + lineOffset;
+
+          cssProperties.add({ property, line: propertyLine });
+        }
+      });
+  }
+
+  function calculateLineOffset(text) {
+    return (text.match(/\n/g) || []).length;
+  }
+
+  function getStyledComponentsCss(directoryPath, styledComponentsCss) {
+    const filesInDirectory = fs.readdirSync(directoryPath);
+    for (const file of filesInDirectory) {
+      if (
+        file === "node_modules" ||
+        file === "build" ||
+        file === "out" ||
+        file === "dist"
+      ) {
+        continue;
+      }
+
+      const filePath = path.join(directoryPath, file);
+      const stats = fs.statSync(filePath);
+      let cssProperties;
+
+      if (stats.isDirectory()) {
+        getStyledComponentsCss(filePath, styledComponentsCss);
+      } else {
+        const fileContents = fs.readFileSync(filePath, "utf8");
+        const styledComponentsRegex =
+          /from ['"]styled-components(?:\/native)?['"]|require\(['"]styled-components(?:\/native)?['"]\)/;
+
+        if (styledComponentsRegex.test(fileContents)) {
+          const styledVariableNames = findStyledVariableNames(fileContents);
+
+          cssProperties = extractStyledComponentsCSS(
+            fileContents,
+            styledVariableNames,
+          );
+          cssProperties = cssProperties.map(info => {
+            return info.property;
+          });
+        }
+
+        if (cssProperties && cssProperties.length > 0) {
+          styledComponentsCss.push({
+            filePath: filePath,
+            cssProperties: cssProperties,
+            fileContent: fs.readFileSync(filePath, "utf8"),
+          });
+        }
       }
     }
 
-    return styledComponentsInfo;
-  }
-
-  function getUserCss(styledComponentsInfo) {
-    const userCss = [];
-
-    styledComponentsInfo.forEach(info => {
-      const fileContent = info.fileContent.split("\n");
-      let isStart = false;
-
-      fileContent.forEach(content => {
-        if (content.includes("import") || content.includes("require")) {
-          return;
-        } else if (content.includes(info.alias)) {
-          isStart = true;
-        } else if (isStart && content.includes(":") && content.includes(";")) {
-          userCss.push(content.split(":")[0].trim());
-        } else if (content.includes("`")) {
-          isStart = false;
-        }
-      });
-
-      info.cssProperties = [...new Set(userCss)];
-    });
+    return styledComponentsCss;
   }
 
   ipcMain.handle(
     "get-styled-components-css-properties",
     (event, directoryPath) => {
-      const files = getFiles(directoryPath);
-      const styledComponentsInfo = getStyledComponentsAlias(files);
-      getUserCss(styledComponentsInfo);
+      const styledComponentsCss = [];
 
-      return styledComponentsInfo;
+      getStyledComponentsCss(directoryPath, styledComponentsCss);
+
+      return styledComponentsCss;
     },
   );
 


### PR DESCRIPTION
# Title
- [[VS Code] 사용자가 작성한 코드에서 CSS 속성 불러오기](https://dune-hammer-c89.notion.site/VS-Code-CSS-a451a14d0bac4ce3b6941cfcbfc0b5d3?pvs=4)

## Description
- @babel/parser의 parse 함수를 사용하여 주어진 파일 내용을 AST로 파싱합니다.
- ImportDeclaration 방문자를 사용하여 파일 내의 모든 import 구문을 찾고 선언된 변수명을 찾습니다.
- require 호출의 인자가 "styled-components"인 경우에도 선언된 변수명을 찾습니다.
- 찾은 변수명을 바탕으로 styled-components가 사용된 파일을 AST로 파싱합니다.
- TaggedTemplateExpression 노드를 찾아 해당 노드가 styled-components의 변수 이름 중 하나로 태그된 경우, 해당 표현식에서 CSS 속성을 추출합니다
- 추출하는 과정에서 CSS가 사용된 줄 정보도 함께 저장합니다.

## Changes (Optional)
- CSS속성을 찾는 과정을 파싱되어 만들어진 AST를 순회하면 찾는 방식으로 변경하였습니다.

## Checklists
- [x] 커밋 메시지 컨벤션에 맞게 작성 했는가?
- [x] 코드 스타일을 잘 확인했는가?
